### PR TITLE
X11 Add support for video/screen scaling

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -61,8 +61,11 @@ gsportmac: $(OBJECTS) compile_time.o
 	arch/mac/makedmg.sh .. GSportDmg GSport GSport 7
 
 # Linux for X builds:
+gsportx: CCOPTS += -DX_RENDER -DX_RENDER_SCALE=2 -DBORDER_WIDTH=8
+gsportx: EXTRA_LIBS += -lXrender
 gsportx: $(OBJECTS) compile_time.o
-	$(LD) $(CCOPTS) $(LDOPTS) $(OBJECTS) compile_time.o $(LDFLAGS) -o $(NAME)$(SUFFIX) $(XLIBS) $(EXTRA_LIBS) -lX11
+	$(LD) $(CCOPTS) $(LDOPTS) $(OBJECTS) compile_time.o $(LDFLAGS) -o $(NAME)$(SUFFIX) \
+		$(XLIBS) $(EXTRA_LIBS) -lX11
 	echo $(OBJECTS)
 	mv gsportx ..
 	cp -f ../config.template ../config.txt 

--- a/src/defc.h
+++ b/src/defc.h
@@ -1,21 +1,21 @@
 /*
  GSport - an Apple //gs Emulator
  Copyright (C) 2010 by GSport contributors
- 
+
  Based on the KEGS emulator written by and Copyright (C) 2003 Kent Dickey
 
- This program is free software; you can redistribute it and/or modify it 
- under the terms of the GNU General Public License as published by the 
- Free Software Foundation; either version 2 of the License, or (at your 
+ This program is free software; you can redistribute it and/or modify it
+ under the terms of the GNU General Public License as published by the
+ Free Software Foundation; either version 2 of the License, or (at your
  option) any later version.
 
- This program is distributed in the hope that it will be useful, but 
- WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  for more details.
 
- You should have received a copy of the GNU General Public License along 
- with this program; if not, write to the Free Software Foundation, Inc., 
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
@@ -58,12 +58,18 @@ void U_STACK_TRACE();
 #define DRECIP_DCYCS_IN_16MS	(1.0 / (DCYCS_IN_16MS))
 
 #ifdef GSPORT_LITTLE_ENDIAN
+#ifdef __GNUC__
+# define BIGEND(a) __builtin_bswap32(a)
+# define GET_BE_WORD16(a)	__builtin_bswap16(a)
+# define GET_BE_WORD32(a)	(BIGEND(a))
+#else
 # define BIGEND(a)    ((((a) >> 24) & 0xff) +			\
 			(((a) >> 8) & 0xff00) + 		\
 			(((a) << 8) & 0xff0000) + 		\
 			(((a) << 24) & 0xff000000))
 # define GET_BE_WORD16(a)	((((a) >> 8) & 0xff) + (((a) << 8) & 0xff00))
 # define GET_BE_WORD32(a)	(BIGEND(a))
+#endif
 #else
 # define BIGEND(a)	(a)
 # define GET_BE_WORD16(a)	(a)
@@ -184,6 +190,7 @@ STRUCT(Engine_reg) {
 STRUCT(Kimage) {
 	void	*dev_handle;
 	void	*dev_handle2;
+	void	*dev_handle3;	/* for xrender ! */
 	byte	*data_ptr;
 	int	width_req;
 	int	width_act;

--- a/src/defcomm.h
+++ b/src/defcomm.h
@@ -146,7 +146,9 @@
 #define ALL_STAT_FLASH_STATE		(1 << (BIT_ALL_STAT_FLASH_STATE))
 #define ALL_STAT_A2VID_PALETTE		(0xf << (BIT_ALL_STAT_A2VID_PALETTE))
 
+#ifndef BORDER_WIDTH
 #define BORDER_WIDTH		32
+#endif
 
 //#define EFF_BORDER_WIDTH	(BORDER_WIDTH + (640-560))
 
@@ -155,8 +157,8 @@
 
 /* BASE_MARGIN_BOTTOM+MARGIN_TOP must equal 62.  There are 262 scan lines */
 /*  at 60Hz (15.7KHz line rate) and so we just make 62 border lines */
-#define BASE_MARGIN_TOP		32
-#define BASE_MARGIN_BOTTOM	30
+#define BASE_MARGIN_TOP		BORDER_WIDTH
+#define BASE_MARGIN_BOTTOM	(BORDER_WIDTH-2)
 #define BASE_MARGIN_LEFT	BORDER_WIDTH
 #define BASE_MARGIN_RIGHT	BORDER_WIDTH
 

--- a/src/prodos.h
+++ b/src/prodos.h
@@ -19,25 +19,31 @@
  59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
+#ifdef __linux__
+#define PACKED __attribute__((packed))
+#else
+#define PACKED
+#endif
+
 typedef struct l2byte_st L2byte;
 struct l2byte_st {
 	byte low;
 	byte hi;
-};
+} PACKED;
 
 typedef struct l3byte_st L3byte;
 struct l3byte_st {
 	byte low;
 	byte hi;
 	byte higher;
-};
+} PACKED;
 
 typedef L2byte Block;
 
 typedef struct pro_time_st Pro_time;
 struct pro_time_st {
 	byte times[4];
-};
+} PACKED;
 
 typedef struct file_entry_st File_entry;
 struct file_entry_st {
@@ -63,7 +69,7 @@ struct file_entry_st {
 	Pro_time last_mod;
 /* 0x25 */
 	Block header_pointer;
-};
+} PACKED;
 
 STRUCT(Vol_hdr) {
 /* 0x4 */
@@ -86,14 +92,14 @@ STRUCT(Vol_hdr) {
 	Block bit_map;
 /* 0x29 */
 	L2byte total_blocks;
-};
+} PACKED;
 
 typedef struct directory_st Directory;
 struct directory_st {
 	Block prev_blk;
 	Block next_blk;
 	File_entry file_entries[13];
-};
+} PACKED;
 
 STRUCT(ProDisk) {
 	int	fd;


### PR DESCRIPTION
On a 4K screen, GSport window is /tiny/ -- this PR adds support for scaling, by adding support for rendering via the XRender extension using a scaling transform. It should be accelerated on pretty much any hardware these days, so has no real impact on performance.

Technically this makes the scaling configurable at runtime, but at the moment it is #defined as x2. I tried to minimize impact on existing code.

This PR also contains a few little fixes for modern GCC, for example there is a commit to use __builtin_bswap; it also force align the prodos.h structures, as that wouldn't work on 64 bits systems at least using gcc.