### PR TITLE
Network support on modern Linux machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ GSport is a portable (in the programming sense) Apple IIgs emulator, based on th
 
 [![alt](https://raw.githubusercontent.com/david-schmidt/gsport/master/doc/web/src/site/resources/images/gsport.png)](https://david-schmidt.github.io/gsport/) [![Download Link](https://raw.githubusercontent.com/david-schmidt/gsport/master/doc/web/src/site/resources/images/download.png)](https://github.com/david-schmidt/gsport/releases)
 
+## Now with network support on Linux!
+
+The GSPort project has been updated to support building for modern 64-bit Linux systems, including support for
+networking via the Uthernet emulation!  This has only been tested on a Ubuntu 18.04 machine and may require some
+tweaking, but the following steps have worked:
+
+* Make sure multiarch support is enabled
+* Download the i386 libraries, especially libX11, libXext, and libpcap (e.g. `sudo apt install libpcap-dev:i386`, etc)
+* `cd src`, `ln -s vars_x86linux vars`, and `make`, and you're on your way
+
+One important note is that the Uthernet emulation relies on sending layer 2 frames in the raw and the use of
+promiscuous mode to discover frames addressed to the MAC of the emulated Uthernet card.  Because of this *wifi is not
+supported*!  I repeat **wifi is not supported**!  It's highly encouraged you start out running this on a machine with
+only one active interface, and that interface should be wired Ethernet.
+
 ## Project Goals
 
 The main goal for GSport is to provide a free, open ecosystem for the continuation of cross-platform development of IIgs emulation.

--- a/src/vars_x86linux
+++ b/src/vars_x86linux
@@ -1,14 +1,15 @@
 TARGET = gsportx
 OBJECTS = $(OBJECTS1) $(TFEOBJ) $(ATOBJ) $(PCAPOBJ) xdriver.o
 CC = gcc
-CCOPTS = -O2 -Wall -fomit-frame-pointer -std=gnu99 -march=i686 -DHAVE_TFE -DHAVE_ATBRIDGE -DTOGGLE_STATUS
-OPTS = -DGSPORT_LITTLE_ENDIAN 
+CCOPTS = -O2 -Wall -fomit-frame-pointer -std=gnu99 -m32 -march=i686
+CPPOPTS = -O2 -Wall -fomit-frame-pointer -std=gnu99 -m32 -march=i686
+OPTS = -DGSPORT_LITTLE_ENDIAN -DDOS_TFE=1 -DHAVE_TFE -DHAVE_ATBRIDGE -DTOGGLE_STATUS
 SUFFIX =
 NAME = gsportx
-LDFLAGS =
+LDFLAGS = -m32 -L/usr/lib32
 LDOPTS =
 LD = g++
-EXTRA_LIBS = -lXext
+EXTRA_LIBS = -lXext -ldl -lpcap
 EXTRA_SPECIALS =
 
 AS = cc


### PR DESCRIPTION
This commit introduces two changes:

* The vars for Linux have been modernized to support building an i386
binary on an x86-64 environment, as x86-64 is the overwhelmingly most
common case these days.

* Vars were introduced to enable Uthernet emulation on Linux.
Instructions on its use are provided in the README.