### PR TITLE
fix(regression): imagewriter BOLD/BASE typo

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -286,7 +286,7 @@ void Imagewriter::resetPrinter()
 		printRes = 2;
 		definedUnit = 96;
 		curCharTable = 1;
-		style = STYLE_BASE;
+		style = STYLE_BOLD;
 		score = SCORE_NONE;
 		extraIntraSpace = 0.0;
 		printUpperContr = true;


### PR DESCRIPTION
Fix a type in the imagewriter code that caused a compile failure.